### PR TITLE
Disable overflow scroll

### DIFF
--- a/assets/css/global.css
+++ b/assets/css/global.css
@@ -35,6 +35,7 @@ html {
 
 body {
   overflow-x: hidden;
+  overscroll-behavior-y: none;
 }
 
 *,


### PR DESCRIPTION
Noticed some white space peeking on overscroll - figured this would be the easiest fix :)

Alternative would be to set a background color, I'd do a hard-stop gradient to match the light blue on top and red on bottom

Your [blog post about PlanetScale, Next and Prisma](https://davidparks.dev/blog/planetscale-deployment-with-prisma/) was dope btw 🙏